### PR TITLE
changed page title for redirect testing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <title>CORE Rules Authoring</title>
+  <title>Redirect Test Branch</title>
 </head>
 
 <body>


### PR DESCRIPTION
If you are on the test site, the Page title should be "Redirect Test Branch" , instead of "CORE Rules Authoring"