### PR TITLE
Reloading test data works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10796,7 +10796,8 @@
     },
     "nanoid": {
       "version": "3.1.29",
-      "resolved": ""
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.29.tgz",
+      "integrity": "sha512-dW2pUSGZ8ZnCFIlBIA31SV8huOGCHb6OwzVCc7A69rb/a+SgPBwfmLvK5TKQ3INPbRkcI8a/Owo0XbiTNH19wg=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -16580,7 +16581,8 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": ""
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             },
             "strip-ansi": {
               "version": "5.2.0",
@@ -16806,7 +16808,8 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": ""
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             },
             "strip-ansi": {
               "version": "5.2.0",
@@ -16855,7 +16858,8 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": ""
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             },
             "strip-ansi": {
               "version": "5.2.0",

--- a/src/components/FileInput/FileInput.tsx
+++ b/src/components/FileInput/FileInput.tsx
@@ -1,19 +1,38 @@
 import { Button } from "@mui/material";
-import { ChangeEventHandler } from "react";
 
 interface Props {
   id: string;
   label: string;
-  onChange: ChangeEventHandler;
+  setFile: (file: File) => void;
 }
 
 export default function FileInput(props: Props) {
-  const { id, label, onChange } = props;
+  const { id, label, setFile } = props;
+
+  const handleFileSelected = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    if (event.currentTarget.files.length) {
+      setFile(event.currentTarget.files[0]);
+    }
+  };
+
+  const handleClick = (
+    event: React.MouseEvent<HTMLInputElement, MouseEvent>
+  ) => {
+    event.currentTarget.value = null;
+  };
 
   return (
     <Button variant="contained" component="label">
       {label}
-      <input key={id} type="file" onChange={onChange} hidden />
+      <input
+        key={id}
+        type="file"
+        onChange={handleFileSelected}
+        onClick={handleClick}
+        hidden
+      />
     </Button>
   );
 }

--- a/src/components/TestStep/LoadTestStep.tsx
+++ b/src/components/TestStep/LoadTestStep.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useEffect, useState } from "react";
 import AppContext, { Status, Steps } from "../AppContext";
 import { excelToJsonDatasets, IDataset } from "../../utils/ExcelDataset";
 import TestStep from "./TestStep";
@@ -6,24 +6,27 @@ import FileInput from "../FileInput/FileInput";
 
 export default function LoadTestStep() {
   const { loadCheck, setLoadCheck, selectedRule } = useContext(AppContext);
+  const [file, setFile] = useState<File>();
 
-  const handleFileSelected = async (event) => {
-    if (event.target.files.length) {
-      const file: File = event.target.files[0];
+  useEffect(() => {
+    const loadExcel = async () => {
       const data: IDataset[] = await excelToJsonDatasets(file);
       setLoadCheck({
         status: Status.Pass,
         details: [file, data],
       });
+    };
+    if (file) {
+      loadExcel();
     }
-  };
+  }, [setLoadCheck, file]);
 
   return (
     <TestStep title="Load Test Data" step={Steps.Load} results={loadCheck}>
       <FileInput
         id={selectedRule}
         label="Test Datasets File..."
-        onChange={handleFileSelected}
+        setFile={setFile}
       />
     </TestStep>
   );


### PR DESCRIPTION
Bug: https://dev.azure.com/cdisc-org/cdisc-library/_workitems/edit/3764
The primary bugfix is the additional "handleClick" function. The remaining changes make the component more react-like.

To Test:
Select a rule.
Select "Test"
Expand "Load Test Data"
Select a file using "TEST DATASETS FILE...".
Note the "Last modified date."
Open the data file in excel and modify the data.
Save and close the file.
Reselect the file using "TEST DATASETS FILE..."
Note that the "Last modified date" should now be the new timestamp.
