### PR TITLE
Invalid yaml-json will save an empty object

### DIFF
--- a/api/providers/CosmosSQLStorage.ts
+++ b/api/providers/CosmosSQLStorage.ts
@@ -141,7 +141,7 @@ const postRule = async (content, creator) => {
     created: date,
     creator,
     isPublished: false,
-    json: spacesToUnderscores(yamlToJSON(content)),
+    json: spacesToUnderscores(yamlToJSON(content) ?? {}),
   };
   const rule = (await dbContainer.items.create(toCreate)).resource;
   return rule;


### PR DESCRIPTION
Without this change, rules with bad yaml would not create a json prop. Subsequent patches would fail because of the missing json prop.

Additionally, I've run a script to add json props to all rules missing the prop.
Closes #81 