### PR TITLE
54, 76 password reset and signup link

### DIFF
--- a/src/services/DataService.ts
+++ b/src/services/DataService.ts
@@ -40,9 +40,9 @@ export class DataService {
       .then(function (responseJson) {
         return {
           id: responseJson.clientPrincipal.userId,
-          name: responseJson.clientPrincipal.claims.filter(
+          name: responseJson.clientPrincipal.claims.find(
             (claim) => claim.typ === "name"
-          )[0].val,
+          )?.val,
         };
       });
   };

--- a/src/services/DataService.ts
+++ b/src/services/DataService.ts
@@ -40,7 +40,9 @@ export class DataService {
       .then(function (responseJson) {
         return {
           id: responseJson.clientPrincipal.userId,
-          name: responseJson.clientPrincipal.userDetails,
+          name: responseJson.clientPrincipal.claims.filter(
+            (claim) => claim.typ === "name"
+          )[0].val,
         };
       });
   };

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -64,7 +64,7 @@
               "clientSecretSettingName": "SWA_CLIENT_SECRET"
             },
             "openIdConnectConfiguration": {
-              "wellKnownOpenIdConfiguration": "https://cdisclibrary.b2clogin.com/cdisclibrary.onmicrosoft.com/b2c_1a_signuporsignin/v2.0/.well-known/openid-configuration"
+              "wellKnownOpenIdConfiguration": "https://cdisclibrary.b2clogin.com/cdisclibrary.onmicrosoft.com/b2c_1a_signupsigninreset/v2.0/.well-known/openid-configuration"
             }
           },
           "login": {

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -2,22 +2,12 @@
   "routes": [
     {
       "route": "/api/*",
-      "methods": [
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE",
-        "GET"
-      ],
-      "allowedRoles": [
-        "authenticated"
-      ]
+      "methods": ["PUT", "POST", "PATCH", "DELETE", "GET"],
+      "allowedRoles": ["authenticated"]
     },
     {
       "route": "/api/*",
-      "allowedRoles": [
-        "authenticated"
-      ]
+      "allowedRoles": ["authenticated"]
     },
     {
       "route": "/login",
@@ -37,17 +27,12 @@
     },
     {
       "route": "/*",
-      "allowedRoles": [
-        "authenticated"
-      ]
+      "allowedRoles": ["authenticated"]
     }
   ],
   "navigationFallback": {
     "rewrite": "index.html",
-    "exclude": [
-      "/images/*.{png,jpg,gif}",
-      "/*.{css,scss,js}"
-    ]
+    "exclude": ["/images/*.{png,jpg,gif}", "/*.{css,scss,js}"]
   },
   "responseOverrides": {
     "400": {
@@ -79,13 +64,11 @@
               "clientSecretSettingName": "SWA_CLIENT_SECRET"
             },
             "openIdConnectConfiguration": {
-              "wellKnownOpenIdConfiguration": "https://cdisclibrary.b2clogin.com/cdisclibrary.onmicrosoft.com/B2C_1_library-sign-in/v2.0/.well-known/openid-configuration"
+              "wellKnownOpenIdConfiguration": "https://cdisclibrary.b2clogin.com/cdisclibrary.onmicrosoft.com/b2c_1a_signuporsignin/v2.0/.well-known/openid-configuration"
             }
           },
           "login": {
-            "scopes": [
-              "openid"
-            ]
+            "scopes": ["openid"]
           }
         }
       }


### PR DESCRIPTION
New flow pieces have been added:
- B2C_1A_SUSIRS_TRUSTFRAMEWORKBASE
- B2C_1A_SUSIRS_TRUSTFRAMEWORKEXTENSIONS
- B2C_1A_SIGNUPSIGNINRESET

B2C_1A_SIGNUPORSIGNIN (vs old B2C_1_library-sign-in) flow must have changed clientPrincipal.userDetails from a username to an email, so the dataservice needed to be changed as well

Currently password reset -> cancel fails for some reason. New bug created: https://github.com/cdisc-org/conformance-rules-editor/issues/108


Changes have been merged to dev, so live preview available here: https://icy-flower-095494b10-dev.centralus.azurestaticapps.net/