### PR TITLE
error trapped when user doesn't have permission

### DIFF
--- a/api/providers/MSGraphUsers.ts
+++ b/api/providers/MSGraphUsers.ts
@@ -99,8 +99,12 @@ const getUsersByName = async (name: string): Promise<IUser[]> => {
 const getUserPermissions = async (user: IUser): Promise<IUser> => {
   if ("CORE_AUTHOR_GROUP" in process.env) {
     var link = `/users/${user.id}/memberOf?$count=true&$filter=id eq '${process.env["CORE_AUTHOR_GROUP"]}'`;
-    const response = await client.api(link).get();
-    user.write_allowed = response.value && response.value.length === 1;
+    try {
+      const response = await client.api(link).get();
+      user.write_allowed = response.value && response.value.length === 1;
+    } catch (exception) {
+      user.write_allowed = false;
+    }
   } else {
     user.write_allowed = true;
   }


### PR DESCRIPTION
To duplicate error before code change:
Ensure your user id is not present in this group: https://portal.azure.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Members/groupId/731986ea-faa8-4656-b445-414c1aa1a737
Login
Note the console reports a 500 with the /api/permissions call.

After applying the code changes, the api should no longer report a 500. Instead the response should return a user object with "write_allowed": false