### PR TITLE
Updated schema to allow no coreid in draft

### DIFF
--- a/public/schema/CORE-base.json
+++ b/public/schema/CORE-base.json
@@ -849,21 +849,33 @@
       "$ref": "#/$defs/Boolean"
     },
     "Core": {
-      "additionalProperties": false,
       "properties": {
-        "Id": {
-          "pattern": "^CORE-\\d{6}$",
-          "type": "string"
-        },
         "Version": {
           "const": "1"
-        },
-        "Status": {
-          "enum": ["Draft", "Published"],
-          "type": "string"
         }
       },
-      "required": ["Id", "Status", "Version"],
+      "oneOf": [
+        {
+          "properties": {
+            "Status": {
+              "const": "Draft"
+            }
+          }
+        },
+        {
+          "properties": {
+            "Id": {
+              "pattern": "^CORE-\\d{6}$",
+              "type": "string"
+            },
+            "Status": {
+              "const": "Published"
+            }
+          },
+          "required": ["Id"]
+        }
+      ],
+      "required": ["Status", "Version"],
       "type": "object"
     },
     "Description": {


### PR DESCRIPTION
You can test the following scenarios in the yaml rule:

**PASS**
```yaml
Core:
  Id: Something
  Version: '1'
  Status: Draft
```

```yaml
Core:
  Version: '1'
  Status: Draft
```

```yaml
Core:
  Version: '1'
  Status: Published
  Id: CORE-000001
```


**FAIL**
```yaml
Core:
  Version: '1'
  Status: Published
  Id: Something
```

```yaml
Core:
  Version: '1'
  Status: Published
```

```yaml
Core:
  Status: Draft
```