### PR TITLE
replace newline chars before checking dirty rule

### DIFF
--- a/src/components/AppContextProvider.tsx
+++ b/src/components/AppContextProvider.tsx
@@ -65,12 +65,14 @@ const AppContextProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
-  const isRuleSelected = useCallback(
-    () => selectedRule !== null,
-    [selectedRule]
-  );
+  const isRuleSelected = useCallback(() => selectedRule !== null, [
+    selectedRule,
+  ]);
+
   const isRuleDirty = useCallback(
-    () => unmodifiedRule !== modifiedRule,
+    () =>
+      unmodifiedRule.replaceAll("\r\n", "\n") !==
+      modifiedRule.replaceAll("\r\n", "\n"),
     [unmodifiedRule, modifiedRule]
   );
 


### PR DESCRIPTION
When a rule is loaded, monaco is automatically converting newline characters to a common convention. This means that some rules will always appear "dirty" when loaded in the editor even after pressing the "discard changes" button.

To reproduce the issue:
In the main branch or on the production website, navigate to the rule with CORE Id: CDISC.SENDIG.6A (available in prod or dev db)
Notice that the "discard changes" button is highlighted, and if it is pressed, remains highlighted. You cannot select another rule.

To test the fix:
In the current branch, when you navigate to the same rule, the "discard changes" button will not be highlighted and you can select another rule.