### PR TITLE
Added json response details for 400s

### DIFF
--- a/api/utils/post_json.ts
+++ b/api/utils/post_json.ts
@@ -22,12 +22,13 @@ export default async (
 
   const res = await fetch(url, init);
 
-  if (res.status === 200) {
+  if (res.status === 200 || res.status === 400) {
     const text = await res.text();
     try {
       context.res = {
         status: res.status,
         body: JSON.parse(text),
+        headers: { "Content-Type": "application/json" },
       };
     } catch (jsonParseException) {
       context.res = {


### PR DESCRIPTION
You can test by going to rule CG0027 and loading the following test file:
[unit-test-coreid-CG0027-negative 1.xlsx](https://github.com/cdisc-org/conformance-rules-editor/files/10903052/unit-test-coreid-CG0027-negative.1.xlsx)

Previously, when this file was loaded, in the results pane, there would be a simple error message stating `400 - bad request`. After this update, it now provides the json error details in the json viewer in the results pane. The message is the message passed from the rules engine service.