### PR TITLE
set codelist and standards in spreadsheet

### DIFF
--- a/src/components/TestStep/LoadDatasetsTestStep.tsx
+++ b/src/components/TestStep/LoadDatasetsTestStep.tsx
@@ -12,7 +12,7 @@ export default function LoadDatasetsTestStep() {
 
   useEffect(() => {
     const loadExcel = async () => {
-      const data: IDataset[] = await excelToJsonDatasets(file);
+      const data = await excelToJsonDatasets(file);
       setLoadDatasetsCheck({
         status: Status.Pass,
         details: [

--- a/src/components/TestStep/LoadDatasetsTestStep.tsx
+++ b/src/components/TestStep/LoadDatasetsTestStep.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState } from "react";
 import AppContext, { DetailsType, Status, Steps } from "../AppContext";
-import { excelToJsonDatasets, IDataset } from "../../utils/ExcelDataset";
+import { excelToJsonDatasets } from "../../utils/ExcelDataset";
 import TestStep from "./TestStep";
 import FileInput from "../FileInput/FileInput";
 

--- a/src/components/TestStep/ResultsTestStep.tsx
+++ b/src/components/TestStep/ResultsTestStep.tsx
@@ -127,8 +127,11 @@ export default function ResultsTestStep() {
       );
 
     const executionPayload = () => ({
+      /* rule */
       rule: jsonCheck.details[0].details,
-      datasets: loadDatasetsCheck.details[1].details,
+      /* datasets, standard, codelists */
+      ...loadDatasetsCheck.details[1].details,
+      /* define_xml */
       ...(loadDefineXMLCheck.status === Status.Pass
         ? { define_xml: loadDefineXMLCheck.details[1].details }
         : {}),


### PR DESCRIPTION
To test,
Run the local rule editor against the current rule engine test point
Select SEND rule 266
Run the rule with this test data:
[unit-test-coreid-SENDIG266-negative.xlsx](https://github.com/cdisc-org/conformance-rules-editor/files/11234422/unit-test-coreid-SENDIG266-negative.xlsx)
You will see a result like the following:
```json
{
  "VS": [
    {
      "executionStatus": "success",
      "domain": "VS",
      "variables": [
        "variable_name"
      ],
      "message": "Variable is not allowed in SDTM/SEND",
      "errors": [
        {
          "value": {
            "variable_name": "WEIRDVAR"
          }
        }
      ]
    }
  ]
}
```

Review the attached Excel file "Library" tab to see if the format makes sense.