### PR TITLE
New operators and meta vars

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -22,7 +22,11 @@ Operations:
 
 ## dy
 
-Calculates the number of days between the DTC and RFSTDTC. Logic: https://github.com/cdisc-org/cdisc-rules-engine/blob/main/cdisc_rules_engine/operations/day_data_validator.py
+> Calculates the number of days between the DTC and RFSTDTC. Logic: https://github.com/cdisc-org/cdisc-rules-engine/blob/main/cdisc_rules_engine/operations/day_data_validator.py
+
+## domain_is_custom
+
+> Checks whether the domain is in the set of domains within the provided standard
 
 ## domain_label
 

--- a/public/schema/CORE-base.json
+++ b/public/schema/CORE-base.json
@@ -153,28 +153,32 @@
             },
             {
               "enum": [
-                "dataset_class",
-                "dataset_is_non_standard",
                 "dataset_label",
-                "dataset_location",
                 "dataset_name",
                 "dataset_size",
-                "dataset_structure",
+                "define_dataset_class",
+                "define_dataset_is_non_standard",
+                "define_dataset_label",
+                "define_dataset_location",
+                "define_dataset_name",
+                "define_dataset_structure",
                 "define_variable_allowed_terms",
                 "define_variable_ccode",
                 "define_variable_data_type",
                 "define_variable_format",
+                "define_variable_is_collected",
                 "define_variable_label",
                 "define_variable_name",
                 "define_variable_origin_type",
                 "define_variable_role",
                 "define_variable_size",
+                "filename",
                 "variable_data_type",
+                "variable_format",
                 "variable_label",
                 "variable_name",
                 "variable_order",
-                "variable_size",
-                "variable_format"
+                "variable_size"
               ],
               "type": "string"
             }
@@ -1011,6 +1015,7 @@
           "operator": {
             "enum": [
               "distinct",
+              "domain_is_custom",
               "domain_label",
               "dy",
               "extract_metadata",


### PR DESCRIPTION
Schema updates for this PR:
https://github.com/cdisc-org/cdisc-rules-engine/pull/402

You should no longer see warnings when using the meta vars or operations within the updated schema