### PR TITLE
185 rule editor goes blank when a excel file other than dataset is uploaded

### DIFF
--- a/src/components/TestStep/ResultsTestStep.tsx
+++ b/src/components/TestStep/ResultsTestStep.tsx
@@ -198,8 +198,8 @@ export default function ResultsTestStep() {
                   details: exception.message,
                 },
                 {
-                  detailsType: DetailsType.text,
-                  details: await exception.details,
+                  detailsType: exception.detailsType,
+                  details: exception.details,
                 },
               ],
             });

--- a/src/services/DataService.ts
+++ b/src/services/DataService.ts
@@ -18,9 +18,15 @@ function responseHasJson(response: Response) {
   return contentType && contentType.includes("application/json");
 }
 
-function DataServiceError(response: Response) {
+async function responseToString(response: Response): Promise<string> {
+  return responseHasJson(response)
+    ? JSON.stringify(await response.json())
+    : response.text();
+}
+
+function DataServiceError(response: Response, details: string) {
   this.message = `Results - Fail: ${response.status} - ${response.statusText}`;
-  this.details = responseHasJson(response) ? response.json() : response.text();
+  this.details = details;
 }
 
 export class DataService {
@@ -207,7 +213,7 @@ export class DataService {
       if (response.status === 200) {
         return response.json();
       } else {
-        throw new DataServiceError(response);
+        throw new DataServiceError(response, await responseToString(response));
       }
     });
   };

--- a/src/services/DataService.ts
+++ b/src/services/DataService.ts
@@ -1,3 +1,4 @@
+import { DetailsType, IResultsDetails } from "../components/AppContext";
 import { IQuery } from "../types/IQuery";
 import { IRule } from "../types/IRule";
 import { IRules } from "../types/IRules";
@@ -13,20 +14,28 @@ export interface ISchema {
   json?: {};
 }
 
+export interface IDataServiceError extends IResultsDetails {
+  message: string;
+}
+
 function responseHasJson(response: Response) {
   const contentType = response.headers.get("content-type");
   return contentType && contentType.includes("application/json");
 }
 
-async function responseToString(response: Response): Promise<string> {
-  return responseHasJson(response)
-    ? JSON.stringify(await response.json())
-    : response.text();
+async function responseToError(response: Response): Promise<IDataServiceError> {
+  const hasJSON = responseHasJson(response);
+  return {
+    details: await (hasJSON ? response.json() : response.text()),
+    detailsType: hasJSON ? DetailsType.json : DetailsType.text,
+    message: `Results - Fail: ${response.status} - ${response.statusText}`,
+  };
 }
 
-function DataServiceError(response: Response, details: string) {
-  this.message = `Results - Fail: ${response.status} - ${response.statusText}`;
-  this.details = details;
+function DataServiceError(error: IDataServiceError) {
+  this.details = error.details;
+  this.detailsType = error.detailsType;
+  this.message = error.message;
 }
 
 export class DataService {
@@ -213,7 +222,7 @@ export class DataService {
       if (response.status === 200) {
         return response.json();
       } else {
-        throw new DataServiceError(response, await responseToString(response));
+        throw new DataServiceError(await responseToError(response));
       }
     });
   };


### PR DESCRIPTION
Before the update, if you load a non-dataset excel test file in the rule tester, the editor will crash and show a blank screen. Now it passes on the json error message from the engine:
Results - Fail: 400 - Bad Request

{"error":"KeyError","message":"\"'datasets' required in request\""}