### PR TITLE
Update Match Datasets documentation

### DIFF
--- a/docs/match_datasets.md
+++ b/docs/match_datasets.md
@@ -1,8 +1,8 @@
 # Match Datasets (Merge)
 
-## Non pivoted relationship - unique variable names
+## Non pivoted relationship - unique check variable names
 
-> MH.MHENDTC >= DM.RFSTDTC
+> Matching on MH.USUBJID = DM.USUBJID: MH.MHENDTC >= DM.RFSTDTC
 
 ```yaml
 Rule Type: Date Arithmetic
@@ -17,9 +17,9 @@ Match Datasets:
       - USUBJID
 ```
 
-## Non pivoted relationship - shared variable names
+## Non pivoted relationship - shared check variable names
 
-> --.VISITDY != TV.VISITDY
+> Matching on --.VISITNUM = TV.VISITNUM: --.VISITDY != TV.VISITDY
 
 ```yaml
 Check:
@@ -31,6 +31,65 @@ Match Datasets:
   - Name: TV
     Keys:
       - VISITNUM
+```
+
+## Non pivoted relationship - non-matching key variable names
+
+Allows for joining datasets with parent datasets using non-matching key variable names. The `Left` key is the name of the variable in the parent dataset and the `Right` key is the name of the variable in the dataset whose name is specified in `Name`.
+
+> Condition: If specimen type is specified in RELSPEC and BS, the values should be the same in both datasets.
+
+> Rule: Matching on RELSPEC.USUBJID = BS.USUBJID and RELSPEC.REFID = BS.BSREFID: RELSPEC.SPEC != BS.BSSPEC
+
+```yaml
+Check:
+  all:
+    - name: SPEC
+      operator: not_equal_to
+      value: BSSPEC
+Match Datasets:
+  - Name: BS
+    Keys:
+      - USUBJID
+      - Left: REFID
+        Right: BSREFID
+Scope:
+  Domains:
+    Include:
+      - RELSPEC
+```
+
+## Non pivoted relationship - left join
+
+Allows for joining datasets with parent datasets, keeping all records from the parent dataset and only records with matching key values from the dataset whose name is specified in `Name`. `Join Type` may be `inner` or `left`. If `Join Type` is not specified, an inner join is performed (i.e., only records with matching key values in both datasets are kept).
+
+> Condition: Extracted or aliquoted specimens should have a parent specimen identified in the RELSPEC dataset.
+
+> Rule: Matching on BE.USUBJID = RELSPEC.USUBJID and BE.BEREFID = RELSPEC.REFID: BEDECOD in ("EXTRACTING", "ALIQUOTING") AND RELSPEC.PARENT is empty
+
+```yaml
+Check:
+  all:
+    - any:
+        - name: BEDECOD
+          operator: equal_to
+          value: EXTRACTING
+        - name: BEDECOD
+          operator: equal_to
+          value: ALIQUOTING
+    - name: PARENT
+      operator: empty
+Match Datasets:
+  - Name: RELSPEC
+    Keys:
+      - USUBJID
+      - Left: BEREFID
+        Right: REFID
+    Join Type: left
+Scope:
+  Domains:
+    Include:
+      - BE
 ```
 
 ## Pivoted (Supp/VL) relationship


### PR DESCRIPTION
The [match_datasets.md](https://github.com/cdisc-org/conformance-rules-editor/blob/main/docs/match_datasets.md) file is updated to describe:
- The use of `Left` and `Right` in `Keys` to specify non-matching key variable names.
- The use of `Join Type` to specify a left join.