### PR TITLE
added optional substandard parsing for editor

### DIFF
--- a/src/utils/ExcelDataset.ts
+++ b/src/utils/ExcelDataset.ts
@@ -19,6 +19,7 @@ export interface IDataset {
 export interface IStandard {
   product: string;
   version: string;
+  substandard?: string;
 }
 
 export interface IVariable {
@@ -181,6 +182,7 @@ const getLibrary = (workbook: WorkBook): IStandard[] => {
   return libraryRows.map<IStandard>((row: {}) => ({
     ...(row["Product"] && { product: row["Product"] }),
     ...(row["Version"] && { version: row["Version"] }),
+    ...(row["Substandard"] && { substandard: row["Substandard"] }),
   }));
 };
 


### PR DESCRIPTION
this ticket updates the interface for the IStandard as well as adding parsing logic to the exceltojson to allow for an optional substandard field after standard and version to accomodate for TIG library requests

to test--run locally, give the excel file to editor and look at the request in the viewer
[unit-test-coreid-TIG0001-negative.xlsx](https://github.com/user-attachments/files/18013991/unit-test-coreid-TIG0001-negative.xlsx)
