### PR TITLE
whitespace logic

### DIFF
--- a/src/utils/ExcelDataset.ts
+++ b/src/utils/ExcelDataset.ts
@@ -82,8 +82,15 @@ const cellTypeMappings: { [type: string]: (cell: CellObject) => void } = {
     cell.v = cell.v.toString();
   },
   Num: (cell) => {
-    cell.t = "n";
-    cell.v = Number(cell.v);
+    const originalValue = cell.v.toString();
+    const trimmedValue = originalValue.trim();
+    if (trimmedValue === '' || trimmedValue === '.') {
+      cell.t = "n";
+      cell.v = null;
+    } else {
+      cell.t = "n";
+      cell.v = Number(cell.v);
+    }
   },
   /* JSON Types */
   Boolean: (cell) => {
@@ -96,8 +103,15 @@ const cellTypeMappings: { [type: string]: (cell: CellObject) => void } = {
     }
   },
   Number: (cell) => {
-    cell.t = "n";
-    cell.v = Number(cell.v);
+    const originalValue = cell.v.toString();
+    const trimmedValue = originalValue.trim();
+    if (trimmedValue === '' || trimmedValue === '.') {
+      cell.t = "n";
+      cell.v = null;
+    } else {
+      cell.t = "n";
+      cell.v = Number(cell.v);
+    }
   },
   String: (cell) => {
     cell.t = "s";

--- a/src/utils/ExcelDataset.ts
+++ b/src/utils/ExcelDataset.ts
@@ -84,7 +84,7 @@ const cellTypeMappings: { [type: string]: (cell: CellObject) => void } = {
   Num: (cell) => {
     const originalValue = cell.v.toString();
     const trimmedValue = originalValue.trim();
-    if (trimmedValue === '' || trimmedValue === '.') {
+    if (trimmedValue === '') {
       cell.t = "n";
       cell.v = null;
     } else {
@@ -105,7 +105,7 @@ const cellTypeMappings: { [type: string]: (cell: CellObject) => void } = {
   Number: (cell) => {
     const originalValue = cell.v.toString();
     const trimmedValue = originalValue.trim();
-    if (trimmedValue === '' || trimmedValue === '.') {
+    if (trimmedValue === '') {
       cell.t = "n";
       cell.v = null;
     } else {


### PR DESCRIPTION
This PR adds parsing logic for when there is whitespace in a num column.  

This pull request improves the handling of numeric cell values in the `ExcelDataset` utility by adding logic to better manage empty and invalid numerical inputs. Specifically, it ensures that cells with empty strings or a single period are treated as null values instead of attempting to convert them to numbers.

Improvements to cell value handling:

* Updated the `Num` cell type mapping to set the cell value to `null` when the value is an empty string or a single period, preventing invalid number conversions.
* Applied the same logic to the `Number` cell type mapping, ensuring consistent handling of empty or invalid numeric inputs by setting the cell value to `null` in these cases.

to test: rule 815 in editor
<img width="1643" height="906" alt="image" src="https://github.com/user-attachments/assets/f32e7d70-d433-4d81-9916-298c38265393" />
SUBJIDN has been reverted to an empty cell -- add a space into the blank cell and then run that data-- it should now be null in request