### PR TITLE
ct editor

### DIFF
--- a/src/utils/ExcelDataset.ts
+++ b/src/utils/ExcelDataset.ts
@@ -199,7 +199,8 @@ const getLibrary = (workbook: WorkBook): IStandard[] => {
   }));
 };
 
-const isCT = (standard: IStandard): boolean => standard.product.endsWith("ct");
+const isCT = (standard: IStandard): boolean => 
+  standard.product.toLowerCase().includes("ct");
 
 const getStandard = (library: IStandard[]): IStandard =>
   library.find((standard) => !isCT(standard));
@@ -207,7 +208,7 @@ const getStandard = (library: IStandard[]): IStandard =>
 const getCodelists = (library: IStandard[]): string[] =>
   library
     .filter(isCT)
-    .map((standard) => `${standard.product}-${standard.version}`);
+    .map((standard) => standard.product);
 
 export const excelToJsonDatasets = async (file: File): Promise<IDatasets> => {
   const workbook: WorkBook = read(await readFile(file), {


### PR DESCRIPTION
This PR resolves the issue Jozef encounted with CT and changes how CT on the library sheet is identified (now looking for 'ct' included.  Looking at the templates for sdtm/send/adam, none of the standard and version contain 'ct' so there should not be any standards misidentified as CT.

This pull request updates the logic for identifying CT products and simplifies how codelists are generated from the Excel dataset utility. The main changes focus on making the CT product detection more robust and streamlining the output format for codelists.

**CT product detection improvements:**

* Updated the `isCT` function to check if the `product` string contains "ct" (case-insensitive), rather than just checking if it ends with "ct", making the detection more flexible.

**Codelist output simplification:**

* Changed the `getCodelists` function to return only the `product` name for CT standards, instead of concatenating the product and version, resulting in a simpler output.