### PR TITLE
ct hotfix

### DIFF
--- a/src/utils/ExcelDataset.ts
+++ b/src/utils/ExcelDataset.ts
@@ -208,7 +208,12 @@ const getStandard = (library: IStandard[]): IStandard =>
 const getCodelists = (library: IStandard[]): string[] =>
   library
     .filter(isCT)
-    .map((standard) => standard.product);
+    .map((standard) => {
+      if (standard.product.includes("-")) {
+        return standard.product;
+      }
+      return `${standard.product}-${standard.version}`;
+    });
 
 export const excelToJsonDatasets = async (file: File): Promise<IDatasets> => {
   const workbook: WorkBook = read(await readFile(file), {


### PR DESCRIPTION
This PR fixes the getCodelists to catch both the product / version library tab for ddf where product is ddfct and the version is the dates and the format for other standards where it is all entered in the product line

