### PR TITLE
Add Executability documentation to author guide

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -8,6 +8,7 @@
 - [Rule Type](rule_type.md)
 - [Scope](scope.md)
 - [Sensitivity](sensitivity.md)
+- [Executability](executability.md)
 - [Metadata Variables](metadata_variables.md)
 - [Test Data](test_data.md)
 - [Test Results](test_results.md)

--- a/docs/executability.md
+++ b/docs/executability.md
@@ -1,0 +1,1 @@
+[](https://raw.githubusercontent.com/cdisc-org/cdisc-rules-engine/main/resources/schema/Executability.md ":include")


### PR DESCRIPTION
Adds Executability documentation to the rule editor author guide by creating docs/executability.md with an :include directive pointing to the Executability.md file in the cdisc-rules-engine repository, following the same pattern as other schema documentation files like Sensitivity and Rule Type. Also updates docs/_sidebar.md to include the Executability entry in the navigation sidebar, making the documentation accessible at the reference guide URL.