### PR TITLE
Document operation parameter `value` in check_parameter reference

### DIFF
--- a/docs/check_parameter.md
+++ b/docs/check_parameter.md
@@ -228,6 +228,16 @@ Terminology term value used in controlled terminology operations for value-based
 ### version
 Version parameter used in codelist operations that require version-specific processing or validation.
 
+### value
+Reference to another operation result, used as the second operand in operations that take two inputs. For example, in the `minus` operation, `name` references the minuend (first list) and `value` references the subtrahend (second list); the operation returns elements in the first list that are not in the second.
+
+```yaml
+- id: $expected_minus_dataset
+  name: $expected_variables
+  operator: minus
+  value: $dataset_variables
+```
+
 ### within
 Specifies the column name used for grouping data before applying validation rules. In the rules engine implementation, this parameter is processed through `replace_prefix()` and used in `groupby()` operations to ensure validation logic is applied within appropriate data boundaries (e.g., by subject, by study).
 

--- a/docs/check_parameter.md
+++ b/docs/check_parameter.md
@@ -228,14 +228,14 @@ Terminology term value used in controlled terminology operations for value-based
 ### version
 Version parameter used in codelist operations that require version-specific processing or validation.
 
-### value
-Reference to another operation result, used as the second operand in operations that take two inputs. For example, in the `minus` operation, `name` references the minuend (first list) and `value` references the subtrahend (second list); the operation returns elements in the first list that are not in the second.
+### subtract
+Reference to another operation result, used as the second operand in operations that take two inputs. For example, in the `minus` operation, `name` references the minuend (first list) and `subtract` references the subtrahend (second list); the operation returns elements in the first list that are not in the second.
 
 ```yaml
 - id: $expected_minus_dataset
   name: $expected_variables
   operator: minus
-  value: $dataset_variables
+  subtract: $dataset_variables
 ```
 
 ### within


### PR DESCRIPTION
docs: add operation parameter `value` to check_parameter reference

Documents the `value` operation parameter used by the minus operation
so the editor reference stays in sync with the rules engine.